### PR TITLE
fix: release-please.yml action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  pull-requests: write
 name: release-please
 jobs:
   release-please:


### PR DESCRIPTION
This adds a permission into the `release-please.yml`:

```yaml
permissions:
  contents: write
  pull-requests: write
```

according to https://github.com/google-github-actions/release-please-action/issues/709#issuecomment-1407490618